### PR TITLE
Rename plugin in the plugins list

### DIFF
--- a/src/carbons.c
+++ b/src/carbons.c
@@ -258,7 +258,7 @@ static PurplePluginInfo info = {
     PURPLE_PRIORITY_DEFAULT,
 
     "core-riba-carbons",
-    "carbons",
+    "XMPP Message Carbons",
     "0.1.2",
 
     "Implements XEP-0280: Message Carbons as a plugin.",


### PR DESCRIPTION
... to make it a little clearer that it's specific for XMPP, and puts it into a similar place in the plugins list to all the other XMPP plugins