### PR TITLE
More flexible build for Lurch4Adium

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,15 @@ all: $(BDIR)/carbons.so
 
 $(BDIR):
 	mkdir -p build
-	
-$(BDIR)/carbons.so: $(SDIR)/carbons.c $(BDIR)
-	$(CC) $(CFLAGS) -fPIC -c $(SDIR)/carbons.c -o $(BDIR)/carbons.o
+
+$(BDIR)/%.o: $(SDIR)/%.c $(BDIR)
+	$(CC) $(CFLAGS) -c $(SDIR)/$*.c -o $@
+
+$(BDIR)/carbons.so: $(BDIR)/carbons.o
 	$(CC) -fPIC -shared $(CFLAGS) $(BDIR)/carbons.o -o $@ $(LFLAGS)
-	
+$(BDIR)/carbons.a: $(BDIR)/carbons.o
+	$(AR) rcs $@ $^
+
 install: $(BDIR)/carbons.so
 	mkdir -p $(PURPLE_PLUGIN_DIR)
 	cp $(BDIR)/carbons.so $(PURPLE_PLUGIN_DIR)/carbons.so

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,18 @@ PIDGIN_DIR=./pidgin-2.11.0
 PURPLE_PLUGIN_SRC_DIR=$(PIDGIN_DIR)/libpurple/plugins
 
 CC ?= gcc
+
 PKG_CONFIG ?= pkg-config
+GLIB_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags glib-2.0)
+GLIB_LDFLAGS ?= $(shell $(PKG_CONFIG) --libs glib-2.0)
+
+LIBPURPLE_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags purple)
+LIBPURPLE_LDFLAGS ?= $(shell $(PKG_CONFIG) --cflags purple) \
+		     -L$(shell $(PKG_CONFIG) --variable=plugindir purple)
+
 XML2_CONFIG ?= xml2-config
+XML2_CFLAGS ?= $(shell $(XML2_CONFIG) --cflags)
+XML2_LDFLAGS ?= $(shell $(XML2_CONFIG) --libs)
 
 LDIR=./lib
 BDIR=./build
@@ -13,25 +23,22 @@ HDIR=./headers
 
 HEADERS=-I$(HDIR)/jabber
 
-LIBPURPLE_CFLAGS=$(shell $(PKG_CONFIG) --cflags purple)
-LIBPURPLE_LDFLAGS=$(shell $(PKG_CONFIG) --cflags purple) \
-		    -L$(shell $(PKG_CONFIG) --variable=plugindir purple)
 
-PKGCFG_C=$(shell $(PKG_CONFIG) --cflags glib-2.0) \
-		 $(LIBPURPLE_CFLAGS) \
-		 $(shell $(XML2_CONFIG) --cflags)
+PKGCFG_C=$(GLIB_CFLAGS) \
+	 $(LIBPURPLE_CFLAGS) \
+	 $(XML2_CFLAGS)
 
-PKGCFG_L=$(shell $(PKG_CONFIG) --libs glib-2.0) \
-		 $(LIBPURPLE_LDFLAGS) \
-		 $(shell $(XML2_CONFIG) --libs) \
+PKGCFG_L=$(GLIB_LDFLAGS) \
+	 $(LIBPURPLE_LDFLAGS) \
+	 $(XML2_LDFLAGS)
 
 CFLAGS=-std=c11 -Wall -g -Wstrict-overflow -D_XOPEN_SOURCE=700 -D_BSD_SOURCE $(PKGCFG_C) $(HEADERS)
 PLUGIN_CPPFLAGS=-DPURPLEPLUGINS
 
 ifneq ("$(wildcard /etc/redhat-release)","")
-	LJABBER=-lxmpp
+	LJABBER?=-lxmpp
 else
-	LJABBER=-ljabber
+	LJABBER?=-ljabber
 endif
 LFLAGS= -ldl -lm $(PKGCFG_L) $(LJABBER)
 

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ PKGCFG_L=$(shell $(PKG_CONFIG) --libs glib-2.0) \
 CFLAGS=-std=c11 -Wall -g -Wstrict-overflow -D_XOPEN_SOURCE=700 -D_BSD_SOURCE $(PKGCFG_C) $(HEADERS)
 
 ifneq ("$(wildcard /etc/redhat-release)","")
-	LFLAGS= -ldl -lm $(PKGCFG_L) -lxmpp
+	LJABBER=-lxmpp
 else
-	LFLAGS= -ldl -lm $(PKGCFG_L) -ljabber
+	LJABBER=-ljabber
 endif
-
+LFLAGS= -ldl -lm $(PKGCFG_L) $(LJABBER)
 
 all: $(BDIR)/carbons.so
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ PKGCFG_L=$(shell $(PKG_CONFIG) --libs glib-2.0) \
 		 $(shell $(XML2_CONFIG) --libs) \
 
 CFLAGS=-std=c11 -Wall -g -Wstrict-overflow -D_XOPEN_SOURCE=700 -D_BSD_SOURCE $(PKGCFG_C) $(HEADERS)
+PLUGIN_CPPFLAGS=-DPURPLEPLUGINS
 
 ifneq ("$(wildcard /etc/redhat-release)","")
 	LJABBER=-lxmpp
@@ -40,10 +41,10 @@ $(BDIR):
 	mkdir -p build
 
 $(BDIR)/%.o: $(SDIR)/%.c $(BDIR)
-	$(CC) $(CFLAGS) -c $(SDIR)/$*.c -o $@
+	$(CC) $(CFLAGS) $(PLUGIN_CPPFLAGS )-c $(SDIR)/$*.c -o $@
 
 $(BDIR)/carbons.so: $(BDIR)/carbons.o
-	$(CC) -fPIC -shared $(CFLAGS) $(BDIR)/carbons.o -o $@ $(LFLAGS)
+	$(CC) -fPIC -shared $(CFLAGS) $(PLUGIN_CPPFLAGS) $(BDIR)/carbons.o -o $@ $(LFLAGS)
 $(BDIR)/carbons.a: $(BDIR)/carbons.o
 	$(AR) rcs $@ $^
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ PURPLE_PLUGIN_DIR=~/.purple/plugins
 PIDGIN_DIR=./pidgin-2.11.0
 PURPLE_PLUGIN_SRC_DIR=$(PIDGIN_DIR)/libpurple/plugins
 
+CC ?= gcc
+PKG_CONFIG ?= pkg-config
+XML2_CONFIG ?= xml2-config
+
 LDIR=./lib
 BDIR=./build
 SDIR=./src
@@ -9,8 +13,17 @@ HDIR=./headers
 
 HEADERS=-I$(HDIR)/jabber
 
-PKGCFG_C=$(shell pkg-config --cflags glib-2.0 purple)  $(shell xml2-config --cflags)
-PKGCFG_L=$(shell pkg-config --libs purple glib-2.0) $(shell xml2-config --libs) -L$(shell pkg-config --variable=plugindir purple)
+LIBPURPLE_CFLAGS=$(shell $(PKG_CONFIG) --cflags purple)
+LIBPURPLE_LDFLAGS=$(shell $(PKG_CONFIG) --cflags purple) \
+		    -L$(shell $(PKG_CONFIG) --variable=plugindir purple)
+
+PKGCFG_C=$(shell $(PKG_CONFIG) --cflags glib-2.0) \
+		 $(LIBPURPLE_CFLAGS) \
+		 $(shell $(XML2_CONFIG) --cflags)
+
+PKGCFG_L=$(shell $(PKG_CONFIG) --libs glib-2.0) \
+		 $(LIBPURPLE_LDFLAGS) \
+		 $(shell $(XML2_CONFIG) --libs) \
 
 CFLAGS=-std=c11 -Wall -g -Wstrict-overflow -D_XOPEN_SOURCE=700 -D_BSD_SOURCE $(PKGCFG_C) $(HEADERS)
 
@@ -27,8 +40,8 @@ $(BDIR):
 	mkdir -p build
 	
 $(BDIR)/carbons.so: $(SDIR)/carbons.c $(BDIR)
-	gcc $(CFLAGS) -fPIC -c $(SDIR)/carbons.c -o $(BDIR)/carbons.o
-	gcc -fPIC -shared $(CFLAGS) $(BDIR)/carbons.o -o $@ $(LFLAGS)
+	$(CC) $(CFLAGS) -fPIC -c $(SDIR)/carbons.c -o $(BDIR)/carbons.o
+	$(CC) -fPIC -shared $(CFLAGS) $(BDIR)/carbons.o -o $@ $(LFLAGS)
 	
 install: $(BDIR)/carbons.so
 	mkdir -p $(PURPLE_PLUGIN_DIR)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ Experimental XEP-0280: Message Carbons plugin for libpurple (Pidgin, Finch, etc.
 4. `make`
 5. A final `make install` should copy the plugin into your libpurple plugin dir.
 
+## MacOS variations
+
+Install dependencies using Homebrew.
+
+```
+brew install glib libxml2
+```
+
+Get a copy of the libpurple soure (from Pidgin), and prepare it so we can use it
+during the build.
+
+```
+hg clone https://bitbucket.org/pidgin/main pidgin
+cd pidgin
+hg checkout v2.10.12
+./configure $(./configure --help | grep -i -- --disable | awk '{ print $1 }')
+```
+
+```
+make LIBPURPLE_CFLAGS=-I${PWD}/pidgin/libpurple LIBPURPLE_LDFLAGS=/Applications/Adium.app/Contents/Frameworks/libpurple.framework/libpurple LJABBER=
+```
+
 ### Windows
 Thanks to EionRobb, you can find a compiled dll to put in your plugin folder here: https://eion.robbmob.com/xmpp-carbons/
 

--- a/src/carbons.c
+++ b/src/carbons.c
@@ -17,8 +17,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#define PURPLE_PLUGINS
-
 #include <glib.h>
 
 #include <stdlib.h>

--- a/src/carbons.c
+++ b/src/carbons.c
@@ -30,6 +30,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "iq.h"
 
+#include "carbons.h"
+
 #define CARBONS_SETTING_NAME "carbons-enabled"
 
 #define CARBONS_XMLNS "urn:xmpp:carbons:2"
@@ -281,11 +283,11 @@ static PurplePluginInfo info = {
 
     "core-riba-carbons",
     "XMPP Message Carbons",
-    "0.1.3",
+    CARBONS_VERSION,
 
     "Implements XEP-0280: Message Carbons as a plugin.",
     "This plugin enables a consistent history view across multiple devices which are online at the same time.",
-    "Richard Bayerle <riba@firemail.cc>",
+    CARBONS_AUTHOR,
     "https://github.com/gkdr/carbons",
 
     carbons_plugin_load,

--- a/src/carbons.h
+++ b/src/carbons.h
@@ -1,0 +1,7 @@
+#ifndef __CARBONS_H
+# define __CARBONS_H
+
+# define CARBONS_VERSION "0.1.3"
+# define CARBONS_AUTHOR "Richard Bayerle <riba@firemail.cc>"
+
+#endif /* __CARBONS_H */


### PR DESCRIPTION
Make the build more flexible by allowing to override the Makefile variables.

This was needed to support making an Adium plugin in shtrom/Lurch4Adium.

Also fix another few things.