### PR TITLE
Pass messages w/ encrypted element through instead of parsing body

### DIFF
--- a/src/carbons.c
+++ b/src/carbons.c
@@ -1,6 +1,7 @@
 /*
 carbons - XEP-0280 plugin for libpurple
 Copyright (C) 2017, Richard Bayerle <riba@firemail.cc>
+Copyright (C) 2018, Daniel Gultsch <daniel@gultsch.de>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -37,6 +38,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define CARBONS_SETTING_NAME "carbons-enabled"
 
 #define CARBONS_XMLNS "urn:xmpp:carbons:2"
+#define OMEMO_XMLNS = "eu.siacs.conversations.axolotl"
 #define XMLNS_ATTR_NAME "xmlns"
 
 #define CARBONS_ENABLE 1
@@ -118,7 +120,8 @@ static void carbons_xml_received_cb(PurpleConnection * gc_p, xmlnode ** stanza_p
     }
 
     body_node_p = xmlnode_get_child(msg_node_p, "body");
-    if (!body_node_p) {
+    encrypted_node_p = xmlnode_get_child_with_namespace(msg_node_p, "encrypted", OMEMO_XMLNS);
+    if (!body_node_p || encrypted_node_p) {
       purple_debug_info("carbons", "Carbon copy of sent message does not contain a body - stripping and passing it through.\n");
       msg_node_p = xmlnode_copy(msg_node_p);
       xmlnode_free(*stanza_pp);


### PR DESCRIPTION
Conversations now sets a fallback message for all OMEMO messages (Other clients like Dino have been doing the same.) Therefore can no longer look for the absents of `<body/>` to decide whether or not we should process this.

I have **not** actually compiled and tested this. So regard this more as a bug report with an attached *possible* solution instead of a ready to merge fix.