### PR TITLE
Use JabberStream to access account's domain instead of parsing the username.

### DIFF
--- a/src/carbons.c
+++ b/src/carbons.c
@@ -212,10 +212,8 @@ static void carbons_discover(PurpleAccount * acc_p) {
   JabberIq * jiq_p = (void *) 0;
   xmlnode * query_node_p = (void *) 0;
   JabberStream * js_p = purple_connection_get_protocol_data(purple_account_get_connection(acc_p));
-  const char * username = purple_account_get_username(acc_p);
-
   jiq_p = jabber_iq_new(js_p, JABBER_IQ_GET);
-  xmlnode_set_attrib(jiq_p->node, "to", jabber_get_domain(username));
+  xmlnode_set_attrib(jiq_p->node, "to", js_p->user->domain);
   query_node_p = xmlnode_new_child(jiq_p->node, "query");
   xmlnode_set_namespace(query_node_p, DISCO_XMLNS);
 


### PR DESCRIPTION
Hi,

It seems that when "Resource" field is empty (Accounts -> Modify Account -> Basic -> field below domain and above password), plugin is unable to discover carbons. I'm not sure how Pidgin assigns resource in that case, I was sure that it'd be simply some semi-random string, but at least for my setup resource was simply NULL.

When resource is empty, `purple_get_username()` returns something like `user@domain/`. When such string is passed to `jabber_get_domain()`, it fails to parse it (due to check in `jabber_id_new_internal()`) and returns `NULL`. Pidgin reports an error about it, but nevertheless it successfully creates `<iq>`, just without `to` attribute. It looks like this:

```
<iq type='get' id='purplecd7d6abe'><query xmlns='http://jabber.org/protocol/disco#info'/></iq>
```

And it should look like this:

```
<iq type='get' id='purplecd7d6abe' to='domain'><query xmlns='http://jabber.org/protocol/disco#info'/></iq>
```

This results in server returning a feature set for a current user, which doesn't contain carbons:

```
<iq id='purplecd7d6abe' type='result' to='user@domain/UUID' from='user@domain'>
    <query xmlns='http://jabber.org/protocol/disco#info'>
        <identity type='registered' category='account'/>
        <feature var='urn:xmpp:mam:2'/>
        <feature var='urn:xmpp:sid:0'/>
        <identity type='pep' category='pubsub'/>
        <feature var='http://jabber.org/protocol/pubsub#publish'/>
    </query>
</iq>
```

And it should be like this (compare "from" attribute):

```
<iq id='purplecd7d6abe' type='result' to='user@domain/UUID' from='domain'>
    <query xmlns='http://jabber.org/protocol/disco#info'>
        <identity type='im' name='Prosody' category='server'/>
        <identity type='pep' name='Prosody' category='pubsub'/>
        ...
        <feature var='urn:xmpp:carbons:2'/>
    </query>
</iq>
```

Instead of parsing the string, we could simply use previously created `JabberStream` the same way as its done across original Pidgin's implementation for XMPP: `js_p->user->domain`, which is what this PR is all about. :)