### PR TITLE
Separate carbon metadata and function prototypes in headers

### DIFF
--- a/src/carbons.c
+++ b/src/carbons.c
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "iq.h"
 
 #include "carbons.h"
-#include "carbons_int.h"
+#include "carbons_internal.h"
 
 #define JABBER_PROTOCOL_ID "prpl-jabber"
 

--- a/src/carbons.c
+++ b/src/carbons.c
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "iq.h"
 
 #include "carbons.h"
+#include "carbons_int.h"
 
 #define JABBER_PROTOCOL_ID "prpl-jabber"
 

--- a/src/carbons.h
+++ b/src/carbons.h
@@ -4,17 +4,4 @@
 # define CARBONS_VERSION "0.2.2"
 # define CARBONS_AUTHOR "Richard Bayerle <riba@firemail.cc>"
 
-void carbons_xml_received_cb(PurpleConnection * gc_p, xmlnode ** stanza_pp);
-void carbons_xml_stripped_cb(PurpleConnection * gc_p, xmlnode ** stanza_pp);
-void carbons_discover(PurpleAccount * acc_p);
-void carbons_discover_cb(JabberStream * js_p, const char * from,
-                                JabberIqType type,   const char * id,
-                                xmlnode * packet_p,  gpointer data_p);
-void carbons_enable_cb(JabberStream * js_p, const char * from,
-                                  JabberIqType type,   const char * id,
-                                  xmlnode * packet_p,  gpointer data_p);
-
-void carbons_account_connect_cb(PurpleAccount * acc_p);
-gboolean carbons_plugin_load(PurplePlugin * plugin_p);
-
 #endif /* __CARBONS_H */

--- a/src/carbons_int.h
+++ b/src/carbons_int.h
@@ -1,0 +1,17 @@
+#ifndef __CARBONS_INT_H
+# define __CARBONS_INT_H
+
+void carbons_xml_received_cb(PurpleConnection * gc_p, xmlnode ** stanza_pp);
+void carbons_xml_stripped_cb(PurpleConnection * gc_p, xmlnode ** stanza_pp);
+void carbons_discover(PurpleAccount * acc_p);
+void carbons_discover_cb(JabberStream * js_p, const char * from,
+                                JabberIqType type,   const char * id,
+                                xmlnode * packet_p,  gpointer data_p);
+void carbons_enable_cb(JabberStream * js_p, const char * from,
+                                  JabberIqType type,   const char * id,
+                                  xmlnode * packet_p,  gpointer data_p);
+
+void carbons_account_connect_cb(PurpleAccount * acc_p);
+gboolean carbons_plugin_load(PurplePlugin * plugin_p);
+
+#endif /* __CARBONS_INT_H */

--- a/src/carbons_internal.h
+++ b/src/carbons_internal.h
@@ -14,4 +14,4 @@ void carbons_enable_cb(JabberStream * js_p, const char * from,
 void carbons_account_connect_cb(PurpleAccount * acc_p);
 gboolean carbons_plugin_load(PurplePlugin * plugin_p);
 
-#endif /* __CARBONS_INT_H */
+#endif /* CARBONS_INTERNAL_H */

--- a/test/test_carbons.c
+++ b/test/test_carbons.c
@@ -6,7 +6,7 @@
 #include "jabber.h"
 
 #include "../src/carbons.h"
-#include "../src/carbons_int.h"
+#include "../src/carbons_internal.h"
 #include "mocks.c"
 
 /**

--- a/test/test_carbons.c
+++ b/test/test_carbons.c
@@ -6,6 +6,7 @@
 #include "jabber.h"
 
 #include "../src/carbons.h"
+#include "../src/carbons_int.h"
 #include "mocks.c"
 
 /**


### PR DESCRIPTION
This is needed to successfully build dependent projects such as Lurch4Adium

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>