### PR TITLE
not override cppflags/ldflags

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.2.2-dev-{build}
+version: 0.2.2
 
 image: Ubuntu1804
 

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ PKGCFG_L=$(GLIB_LDFLAGS) \
 	 $(LIBPURPLE_LDFLAGS) \
 	 $(XML2_LDFLAGS)
 
-FLAGS+=-std=c11 -Wall -g -Wstrict-overflow -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE
-CFLAGS=$(FLAGS) $(PKGCFG_C) $(HEADERS)
+FLAGS+=-std=c11 -Wall -g -Wstrict-overflow -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE $(CPPFLAGS)
+CFLAGS+= $(FLAGS) $(PKGCFG_C) $(HEADERS)
 CFLAGS_C= $(CFLAGS) -fPIC -shared
 CFLAGS_T= $(CFLAGS) -O0
 PLUGIN_CPPFLAGS=-DPURPLE_PLUGINS
@@ -44,7 +44,7 @@ else
 	LJABBER?=-ljabber
 endif
 
-LFLAGS= -ldl -lm $(PKGCFG_L) $(LJABBER)
+LFLAGS= $(LDFLAGS) -ldl -lm $(PKGCFG_L) $(LJABBER)
 LFLAGS_T= $(LFLAGS) -lpurple -lcmocka -Wl,-rpath,$(PURPLE_DIR) \
 	-Wl,--wrap=purple_account_is_connected \
 	-Wl,--wrap=purple_account_get_connection \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# carbons 0.2.1
-[![Build status](https://ci.appveyor.com/api/projects/status/0t32ouomatf2teld/branch/dev?svg=true)](https://ci.appveyor.com/project/gkdr/carbons/branch/dev)
-[![codecov](https://codecov.io/gh/gkdr/carbons/branch/dev/graph/badge.svg)](https://codecov.io/gh/gkdr/carbons)
+# carbons 0.2.2
+[![Build status](https://ci.appveyor.com/api/projects/status/0t32ouomatf2teld/branch/master?svg=true)](https://ci.appveyor.com/project/gkdr/carbons/branch/dev)
+[![codecov](https://codecov.io/gh/gkdr/carbons/branch/master/graph/badge.svg)](https://codecov.io/gh/gkdr/carbons)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/gkdr/carbons.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/gkdr/carbons/context:cpp)
 
 Experimental [XEP-0280: Message Carbons](https://xmpp.org/extensions/xep-0280.html) plugin for libpurple (Pidgin, Finch, etc.)

--- a/src/carbons.h
+++ b/src/carbons.h
@@ -1,7 +1,7 @@
 #ifndef __CARBONS_H
 # define __CARBONS_H
 
-# define CARBONS_VERSION "0.2.1"
+# define CARBONS_VERSION "0.2.2"
 # define CARBONS_AUTHOR "Richard Bayerle <riba@firemail.cc>"
 
 void carbons_xml_received_cb(PurpleConnection * gc_p, xmlnode ** stanza_pp);


### PR DESCRIPTION
Preserve cppflags and ldflags variables so that build options used for hardening are preserved as well.

This allows distribution of hardened builds, which helps downstream distribution in GNU/Linux distro.